### PR TITLE
Update engine branding to SF-PG-300925

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
   [![Stockfish][stockfish128-logo]][website-link]
 
-  <h3>Stockfish</h3>
+  <h3>SF-PG-300925</h3>
 
-  A free and strong UCI chess engine.
+  Motor de ajedrez derivado de Stockfish con soporte para libros Polyglot (.bin) e ideas aportadas por la IA de ChatGPT.
   <br>
-  <strong>[Explore Stockfish docs »][wiki-link]</strong>
+  <strong>Id UCI oficial: SF-PG-300925</strong>
+  <br>
+  <strong>Autores: Jorge Ruiz &amp; Codex ChatGPT</strong>
+  <br>
+  <strong>[Documentación de Stockfish »][wiki-link]</strong>
   <br>
   <br>
   [Report bug][issue-link]
@@ -31,16 +35,35 @@
 
 ## Overview
 
-[Stockfish][website-link] is a **free and strong UCI chess engine** derived from
-Glaurung 2.1 that analyzes chess positions and computes the optimal moves.
+SF-PG-300925 es un motor de ajedrez UCI **derivado de [Stockfish][website-link]**
+que mantiene su fuerza táctica y estratégica, incorpora soporte nativo para
+libros de aperturas Polyglot (`.bin`) y suma ideas generadas con la asistencia
+de la inteligencia artificial de ChatGPT. El identificador que muestra el
+ejecutable al ejecutar el comando `uci` es `id name SF-PG-300925`, lo que
+permite reconocer el motor en interfaces como Fritz 20, CuteChess y otras GUI.
 
-Stockfish **does not include a graphical user interface** (GUI) that is required
-to display a chessboard and to make it easy to input moves. These GUIs are
-developed independently from Stockfish and are available online. **Read the
-documentation for your GUI** of choice for information about how to use
-Stockfish with it.
+Al igual que Stockfish, este proyecto **no incluye una interfaz gráfica**. Para
+visualizar el tablero y facilitar la introducción de jugadas debes utilizar una
+GUI compatible y seguir la **documentación específica de tu interfaz** para
+cargar el motor.
 
-See also the Stockfish [documentation][wiki-usage-link] for further usage help.
+Para profundizar en los conceptos y opciones heredados de Stockfish, consulta la
+[documentación oficial][wiki-usage-link].
+
+## Autores y créditos
+
+* **Jorge Ruiz** – Integración de mejoras, soporte Polyglot y mantenimiento del
+  derivado SF-PG-300925.
+* **Codex ChatGPT** – Ideas estratégicas asistidas por IA y colaboración en la
+  adaptación del motor.
+* **Desarrolladores de Stockfish** – La lista completa de autores originales se
+  encuentra en el archivo [AUTHORS](AUTHORS) y en [Top CPU Contributors.txt](Top CPU Contributors.txt).
+
+Este trabajo es un derivado directo de Stockfish y respeta la licencia GPLv3
+incluida en [Copying.txt][license-link].
+
+Consulta también la [documentación de Stockfish][wiki-usage-link] para obtener
+más detalles de uso y configuración avanzada.
 
 ## Files
 

--- a/tests/instrumented.py
+++ b/tests/instrumented.py
@@ -8,6 +8,7 @@ import os
 from testing import (
     EPD,
     TSAN,
+    ENGINE_ID,
     Stockfish as Engine,
     MiniTestFramework,
     OrderedClassMembers,
@@ -214,7 +215,7 @@ class TestInteractive(metaclass=OrderedClassMembers):
         self.stockfish.clear_output()
 
     def test_startup_output(self):
-        self.stockfish.starts_with("Stockfish")
+        self.stockfish.starts_with(ENGINE_ID)
 
     def test_uci_command(self):
         self.stockfish.send_command("uci")
@@ -426,7 +427,7 @@ class TestSyzygy(metaclass=OrderedClassMembers):
         self.stockfish.clear_output()
 
     def test_syzygy_setup(self):
-        self.stockfish.starts_with("Stockfish")
+        self.stockfish.starts_with(ENGINE_ID)
         self.stockfish.send_command("uci")
         self.stockfish.send_command(
             f"setoption name SyzygyPath value {os.path.join(PATH, 'syzygy')}"

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -27,6 +27,8 @@ MAX_TIMEOUT = 60 * 5
 
 PATH = pathlib.Path(__file__).parent.resolve()
 
+ENGINE_ID = "SF-PG-300925"
+
 
 class Valgrind:
     @staticmethod


### PR DESCRIPTION
## Summary
- refresh the README to describe SF-PG-300925, crediting Jorge Ruiz, Codex ChatGPT, and the Stockfish developers
- introduce a shared ENGINE_ID constant and use it in the test harness so the expected UCI id matches SF-PG-300925

## Testing
- python -m compileall tests

------
https://chatgpt.com/codex/tasks/task_e_68dbc375a4388327a7d23b44f58fd465