### PR TITLE
Rename binary to SF-PG-300925 and update branding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 # SF-PG-300925 Authors
 Jorge Ruiz
 Codex ChatGPT
+Desarrolladores de Stockfish (lista completa a continuación)
 
 # Founders of the Stockfish project and Fishtest infrastructure
 Tord Romstad (romstad)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <div align="center">
 
-  [![Stockfish][stockfish128-logo]][website-link]
+  <img src="assets/sf-pg-300925-logo.svg" alt="Logotipo SF-PG-300925" width="220">
+  <br>
 
   <h3>SF-PG-300925</h3>
 
@@ -8,7 +9,7 @@
   <br>
   <strong>Id UCI oficial: SF-PG-300925</strong>
   <br>
-  <strong>Autores: Jorge Ruiz &amp; Codex ChatGPT</strong>
+  <strong>Autores: Desarrolladores de Stockfish, Jorge Ruiz &amp; Codex ChatGPT</strong>
   <br>
   <strong>[Documentación de Stockfish »][wiki-link]</strong>
   <br>
@@ -41,6 +42,9 @@ libros de aperturas Polyglot (`.bin`) y suma ideas generadas con la asistencia
 de la inteligencia artificial de ChatGPT. El identificador que muestra el
 ejecutable al ejecutar el comando `uci` es `id name SF-PG-300925`, lo que
 permite reconocer el motor en interfaces como Fritz 20, CuteChess y otras GUI.
+El binario resultante tras la compilación se denomina `SF-PG-300925` en
+Linux/macOS y `SF-PG-300925.exe` en Windows para reflejar explícitamente la
+autoría del derivado.
 
 Al igual que Stockfish, este proyecto **no incluye una interfaz gráfica**. Para
 visualizar el tablero y facilitar la introducción de jugadas debes utilizar una
@@ -52,17 +56,19 @@ Para profundizar en los conceptos y opciones heredados de Stockfish, consulta la
 
 ## Autores y créditos
 
+* **Desarrolladores de Stockfish** – Autoría original del motor base y
+  mantenedores del ecosistema Stockfish. Consulta los listados completos en
+  [AUTHORS](AUTHORS) y en [Top CPU Contributors.txt](Top CPU Contributors.txt).
 * **Jorge Ruiz** – Integración de mejoras, soporte Polyglot y mantenimiento del
   derivado SF-PG-300925.
-* **Codex ChatGPT** – Ideas estratégicas asistidas por IA y colaboración en la
-  adaptación del motor.
-* **Desarrolladores de Stockfish** – La lista completa de autores originales se
-  encuentra en el archivo [AUTHORS](AUTHORS) y en [Top CPU Contributors.txt](Top CPU Contributors.txt).
-  Cada archivo fuente de `src/` mantiene en su encabezado una referencia expresa
-  a estos colaboradores para honrar su contribución esencial.
+* **Codex ChatGPT** – Ideación asistida por IA, documentación y colaboración en
+  la adaptación del motor.
 
-Este trabajo es un derivado directo de Stockfish y respeta la licencia GPLv3
-incluida en [Copying.txt][license-link].
+Este trabajo es un derivado directo de Stockfish y se publica con la autoría
+colectiva de las tres partes anteriores, respetando la licencia GPLv3 incluida
+en [Copying.txt][license-link]. Cada archivo fuente de `src/` mantiene en su
+encabezado una referencia expresa a los desarrolladores de Stockfish para
+honrar su contribución esencial.
 
 Consulta también la [documentación de Stockfish][wiki-usage-link] para obtener
 más detalles de uso y configuración avanzada.

--- a/assets/sf-pg-300925-logo.svg
+++ b/assets/sf-pg-300925-logo.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" role="img" aria-labelledby="title desc">
+  <title id="title">SF-PG-300925 chess engine logo</title>
+  <desc id="desc">Logo featuring a rook and a knight silhouette next to the text SF-PG-300925 and UCI Chess Engine.</desc>
+  <defs>
+    <linearGradient id="rookGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#d9dde2"/>
+      <stop offset="100%" stop-color="#9ea4ac"/>
+    </linearGradient>
+    <linearGradient id="knightGradient" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#3aa1d9"/>
+      <stop offset="100%" stop-color="#14608e"/>
+    </linearGradient>
+  </defs>
+  <rect x="32" y="340" width="120" height="36" rx="6" fill="url(#rookGradient)"/>
+  <rect x="48" y="300" width="88" height="32" rx="6" fill="url(#rookGradient)"/>
+  <rect x="42" y="180" width="100" height="122" fill="url(#rookGradient)"/>
+  <rect x="32" y="152" width="120" height="32" fill="url(#rookGradient)"/>
+  <rect x="40" y="116" width="104" height="32" fill="url(#rookGradient)"/>
+  <rect x="52" y="80" width="80" height="32" fill="url(#rookGradient)"/>
+  <rect x="60" y="60" width="64" height="20" rx="6" fill="url(#rookGradient)"/>
+  <path fill="url(#knightGradient)" d="M315 360c-12 30-51 52-101 52-60 0-110-42-110-110 0-40 18-72 42-94l-24-18c-8-6-10-17-3-24l40-40-16-22c-4-6-2-14 5-18 14-7 31-12 50-12 42 0 90 24 90 86 0 18-6 36-14 50 19 14 35 38 35 78 0 28-8 52-17 72l14 14c6 6 6 16 0 22l-9 9c-6 6-16 6-22 0l-10-10z"/>
+  <path fill="white" fill-opacity="0.18" d="M214 138c14-8 32-12 51-10 12 1 25 4 36 10-10-33-45-52-78-48-12 1-23 4-32 9l23 31z"/>
+  <circle cx="282" cy="182" r="12" fill="#0f3c5d"/>
+  <text x="210" y="380" fill="#0f3c5d" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="54" text-anchor="middle">SF-PG-300925</text>
+  <text x="210" y="430" fill="#4a545f" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="36" letter-spacing="2.5" text-anchor="middle">UCI CHESS ENGINE</text>
+</svg>

--- a/src/Makefile
+++ b/src/Makefile
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-	EXE = stockfish.exe
+        EXE = SF-PG-300925.exe
 else
-	EXE = stockfish
+        EXE = SF-PG-300925
 endif
 
 ### Installation dir definitions
@@ -886,7 +886,7 @@ endif
 
 help:
 	@echo "" && \
-	echo "To compile stockfish, type: " && \
+	echo "To compile SF-PG-300925, type: " && \
 	echo "" && \
 	echo "make -j target [ARCH=arch] [COMP=compiler] [COMPCXX=cxx]" && \
 	echo "" && \
@@ -1004,16 +1004,16 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@rm -f SF-PG-300925 SF-PG-300925.exe stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f stockfish.profdata *.profraw
-	@rm -f stockfish.*args*
-	@rm -f stockfish.*lt*
-	@rm -f stockfish.res
+	@rm -f SF-PG-300925.profdata stockfish.profdata *.profraw
+	@rm -f SF-PG-300925.*args* stockfish.*args*
+	@rm -f SF-PG-300925.*lt* stockfish.*lt*
+	@rm -f SF-PG-300925.res stockfish.res
 	@rm -f ./-lstdc++.res
 
 # evaluation network (nnue)
@@ -1113,9 +1113,9 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=SF-PG-300925.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=stockfish.profdata' \
+	EXTRACXXFLAGS='-fprofile-use=SF-PG-300925.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
@@ -1141,9 +1141,9 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=stockfish.profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=SF-PG-300925.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=stockfish.profdata' \
+	EXTRACXXFLAGS='-fprofile-instr-use=SF-PG-300925.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 


### PR DESCRIPTION
## Summary
- rename the produced executable to SF-PG-300925 and update clean/profile targets to handle the new name
- refresh the README with the bundled SF-PG-300925 logo and expanded author credits acknowledging the Stockfish developers, Jorge Ruiz, and Codex ChatGPT
- document the combined authorship in AUTHORS and add the project logo asset

## Testing
- make help | head -n 5

------
https://chatgpt.com/codex/tasks/task_e_68dbd07a2d808327afe17b763ec36187