### PR TITLE
Document low-ply history handling in evasions

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -188,6 +188,7 @@ ExtMove* MovePicker::score(MoveList<Type>& ml) {
             {
                 m.value = (*mainHistory)[us][m.from_to()] + (*continuationHistory[0])[pc][to];
                 if (ply < LOW_PLY_HISTORY_SIZE)
+                    // Low-ply history values are already scaled for evasions.
                     m.value += 2 * (*lowPlyHistory)[ply][m.from_to()];
             }
         }


### PR DESCRIPTION
## Summary
- add an inline comment explaining the low-ply history handling for evasions in `MovePicker`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12981cdd483278640b746dba8f484