### PR TITLE
Rename engine branding to SF-PG-041025

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# SF-PG-300925 Authors
+# SF-PG-041025 Authors
 Jorge Ruiz
 Codex ChatGPT
 Desarrolladores de Stockfish (lista completa a continuación)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
 
-  <img src="assets/sf-pg-300925-logo.svg" alt="Logotipo SF-PG-300925" width="220">
+  <img src="assets/sf-pg-041025-logo.svg" alt="Logotipo SF-PG-041025" width="220">
   <br>
 
-  <h3>SF-PG-300925</h3>
+  <h3>SF-PG-041025</h3>
 
   Motor de ajedrez derivado de Stockfish con soporte para libros Polyglot (.bin) e ideas aportadas por la IA de ChatGPT.
   <br>
-  <strong>Id UCI oficial: SF-PG-300925</strong>
+  <strong>Id UCI oficial: SF-PG-041025</strong>
   <br>
   <strong>Autores: Desarrolladores de Stockfish, Jorge Ruiz &amp; Codex ChatGPT</strong>
   <br>
@@ -36,14 +36,14 @@
 
 ## Overview
 
-SF-PG-300925 es un motor de ajedrez UCI **derivado de [Stockfish][website-link]**
+SF-PG-041025 es un motor de ajedrez UCI **derivado de [Stockfish][website-link]**
 que mantiene su fuerza táctica y estratégica, incorpora soporte nativo para
 libros de aperturas Polyglot (`.bin`) y suma ideas generadas con la asistencia
 de la inteligencia artificial de ChatGPT. El identificador que muestra el
-ejecutable al ejecutar el comando `uci` es `id name SF-PG-300925`, lo que
+ejecutable al ejecutar el comando `uci` es `id name SF-PG-041025`, lo que
 permite reconocer el motor en interfaces como Fritz 20, CuteChess y otras GUI.
-El binario resultante tras la compilación se denomina `SF-PG-300925` en
-Linux/macOS y `SF-PG-300925.exe` en Windows para reflejar explícitamente la
+El binario resultante tras la compilación se denomina `SF-PG-041025` en
+Linux/macOS y `SF-PG-041025.exe` en Windows para reflejar explícitamente la
 autoría del derivado.
 
 Al igual que Stockfish, este proyecto **no incluye una interfaz gráfica**. Para
@@ -60,7 +60,7 @@ Para profundizar en los conceptos y opciones heredados de Stockfish, consulta la
   mantenedores del ecosistema Stockfish. Consulta los listados completos en
   [AUTHORS](AUTHORS) y en [Top CPU Contributors.txt](Top CPU Contributors.txt).
 * **Jorge Ruiz** – Integración de mejoras, soporte Polyglot y mantenimiento del
-  derivado SF-PG-300925.
+  derivado SF-PG-041025.
 * **Codex ChatGPT** – Ideación asistida por IA, documentación y colaboración en
   la adaptación del motor.
 

--- a/assets/sf-pg-041025-logo.svg
+++ b/assets/sf-pg-041025-logo.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 520" role="img" aria-labelledby="title desc">
-  <title id="title">SF-PG-300925 chess engine logo</title>
-  <desc id="desc">Logo featuring a rook and a knight silhouette next to the text SF-PG-300925 and UCI Chess Engine.</desc>
+  <title id="title">SF-PG-041025 chess engine logo</title>
+  <desc id="desc">Logo featuring a rook and a knight silhouette next to the text SF-PG-041025 and UCI Chess Engine.</desc>
   <defs>
     <linearGradient id="rookGradient" x1="0" x2="0" y1="0" y2="1">
       <stop offset="0%" stop-color="#d9dde2"/>
@@ -21,6 +21,6 @@
   <path fill="url(#knightGradient)" d="M315 360c-12 30-51 52-101 52-60 0-110-42-110-110 0-40 18-72 42-94l-24-18c-8-6-10-17-3-24l40-40-16-22c-4-6-2-14 5-18 14-7 31-12 50-12 42 0 90 24 90 86 0 18-6 36-14 50 19 14 35 38 35 78 0 28-8 52-17 72l14 14c6 6 6 16 0 22l-9 9c-6 6-16 6-22 0l-10-10z"/>
   <path fill="white" fill-opacity="0.18" d="M214 138c14-8 32-12 51-10 12 1 25 4 36 10-10-33-45-52-78-48-12 1-23 4-32 9l23 31z"/>
   <circle cx="282" cy="182" r="12" fill="#0f3c5d"/>
-  <text x="210" y="380" fill="#0f3c5d" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="54" text-anchor="middle">SF-PG-300925</text>
+  <text x="210" y="380" fill="#0f3c5d" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="54" text-anchor="middle">SF-PG-041025</text>
   <text x="210" y="430" fill="#4a545f" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="36" letter-spacing="2.5" text-anchor="middle">UCI CHESS ENGINE</text>
 </svg>

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-# SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+# SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
 # Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 #
 # Stockfish is free software: you can redistribute it and/or modify
@@ -39,9 +39,9 @@ endif
 
 ### Executable name
 ifeq ($(target_windows),yes)
-        EXE = SF-PG-300925.exe
+        EXE = SF-PG-041025.exe
 else
-        EXE = SF-PG-300925
+        EXE = SF-PG-041025
 endif
 
 ### Installation dir definitions
@@ -886,7 +886,7 @@ endif
 
 help:
 	@echo "" && \
-	echo "To compile SF-PG-300925, type: " && \
+	echo "To compile SF-PG-041025, type: " && \
 	echo "" && \
 	echo "make -j target [ARCH=arch] [COMP=compiler] [COMPCXX=cxx]" && \
 	echo "" && \
@@ -1004,16 +1004,16 @@ clean: objclean profileclean
 
 # clean binaries and objects
 objclean:
-	@rm -f SF-PG-300925 SF-PG-300925.exe stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
+	@rm -f SF-PG-041025 SF-PG-041025.exe stockfish stockfish.exe *.o ./syzygy/*.o ./nnue/*.o ./nnue/features/*.o
 
 # clean auxiliary profiling files
 profileclean:
 	@rm -rf profdir
 	@rm -f bench.txt *.gcda *.gcno ./syzygy/*.gcda ./nnue/*.gcda ./nnue/features/*.gcda *.s PGOBENCH.out
-	@rm -f SF-PG-300925.profdata stockfish.profdata *.profraw
-	@rm -f SF-PG-300925.*args* stockfish.*args*
-	@rm -f SF-PG-300925.*lt* stockfish.*lt*
-	@rm -f SF-PG-300925.res stockfish.res
+	@rm -f SF-PG-041025.profdata stockfish.profdata *.profraw
+	@rm -f SF-PG-041025.*args* stockfish.*args*
+	@rm -f SF-PG-041025.*lt* stockfish.*lt*
+	@rm -f SF-PG-041025.res stockfish.res
 	@rm -f ./-lstdc++.res
 
 # evaluation network (nnue)
@@ -1113,9 +1113,9 @@ clang-profile-make:
 	all
 
 clang-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=SF-PG-300925.profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=SF-PG-041025.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-use=SF-PG-300925.profdata' \
+	EXTRACXXFLAGS='-fprofile-use=SF-PG-041025.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 
@@ -1141,9 +1141,9 @@ icx-profile-make:
 	all
 
 icx-profile-use:
-	$(XCRUN) $(LLVM_PROFDATA) merge -output=SF-PG-300925.profdata *.profraw
+	$(XCRUN) $(LLVM_PROFDATA) merge -output=SF-PG-041025.profdata *.profraw
 	$(MAKE) ARCH=$(ARCH) COMP=$(COMP) \
-	EXTRACXXFLAGS='-fprofile-instr-use=SF-PG-300925.profdata' \
+	EXTRACXXFLAGS='-fprofile-instr-use=SF-PG-041025.profdata' \
 	EXTRALDFLAGS='-fprofile-use ' \
 	all
 

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/benchmark.h
+++ b/src/benchmark.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/bitboard.cpp
+++ b/src/bitboard.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/engine.h
+++ b/src/engine.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/history.h
+++ b/src/history.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify
@@ -42,7 +42,7 @@ namespace {
 // Engine branding. We expose only the SF-PG identifier to both console headers
 // and the UCI "id name" field so that no upstream Stockfish development tag is
 // appended.
-constexpr std::string_view engine_name = "SF-PG-300925";
+constexpr std::string_view engine_name = "SF-PG-041025";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We
@@ -115,9 +115,9 @@ class Logger {
 }  // namespace
 
 
-// Returns the display name of SF-PG-300925. The engine intentionally avoids
+// Returns the display name of SF-PG-041025. The engine intentionally avoids
 // appending the upstream Stockfish development tag so that the banner reads
-// exactly "SF-PG-300925".
+// exactly "SF-PG-041025".
 std::string engine_version_info() {
     return std::string(engine_name);
 }

--- a/src/misc.h
+++ b/src/misc.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/movegen.cpp
+++ b/src/movegen.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/movepick.h
+++ b/src/movepick.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/features/half_ka_v2_hm.cpp
+++ b/src/nnue/features/half_ka_v2_hm.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/features/half_ka_v2_hm.h
+++ b/src/nnue/features/half_ka_v2_hm.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/layers/affine_transform.h
+++ b/src/nnue/layers/affine_transform.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/layers/affine_transform_sparse_input.h
+++ b/src/nnue/layers/affine_transform_sparse_input.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/layers/clipped_relu.h
+++ b/src/nnue/layers/clipped_relu.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/layers/sqr_clipped_relu.h
+++ b/src/nnue/layers/sqr_clipped_relu.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/network.cpp
+++ b/src/nnue/network.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/network.h
+++ b/src/nnue/network.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_accumulator.cpp
+++ b/src/nnue/nnue_accumulator.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_accumulator.h
+++ b/src/nnue/nnue_accumulator.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_architecture.h
+++ b/src/nnue/nnue_architecture.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_common.h
+++ b/src/nnue/nnue_common.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_feature_transformer.h
+++ b/src/nnue/nnue_feature_transformer.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_misc.cpp
+++ b/src/nnue/nnue_misc.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/nnue_misc.h
+++ b/src/nnue/nnue_misc.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/nnue/simd.h
+++ b/src/nnue/simd.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/numa.h
+++ b/src/numa.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/perft.h
+++ b/src/perft.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/polybook.h
+++ b/src/polybook.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/position.h
+++ b/src/position.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/score.cpp
+++ b/src/score.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/score.h
+++ b/src/score.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/search.h
+++ b/src/search.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/syzygy/tbprobe.cpp
+++ b/src/syzygy/tbprobe.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/syzygy/tbprobe.h
+++ b/src/syzygy/tbprobe.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/thread.h
+++ b/src/thread.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/thread_win32_osx.h
+++ b/src/thread_win32_osx.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/timeman.cpp
+++ b/src/timeman.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/timeman.h
+++ b/src/timeman.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/tt.h
+++ b/src/tt.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/tune.cpp
+++ b/src/tune.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/tune.h
+++ b/src/tune.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/ucioption.cpp
+++ b/src/ucioption.cpp
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/src/ucioption.h
+++ b/src/ucioption.h
@@ -1,5 +1,5 @@
 /*
-  SF-PG-300925, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
+  SF-PG-041025, a Stockfish-based UCI chess engine with Polyglot (.bin) book support and ChatGPT-inspired ideas
   Authors: Jorge Ruiz, Codex ChatGPT, and the Stockfish developers (see AUTHORS file)
 
   Stockfish is free software: you can redistribute it and/or modify

--- a/tests/testing.py
+++ b/tests/testing.py
@@ -27,7 +27,7 @@ MAX_TIMEOUT = 60 * 5
 
 PATH = pathlib.Path(__file__).parent.resolve()
 
-ENGINE_ID = "SF-PG-300925"
+ENGINE_ID = "SF-PG-041025"
 
 
 class Valgrind:


### PR DESCRIPTION
## Summary
- update documentation, metadata, and tests to use the new SF-PG-041025 identifier
- rename the executable target and SVG asset to match the refreshed branding

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e12fcf161083278cbafd3a5fa7d42f